### PR TITLE
Frontend Page Routes in README

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -4,9 +4,13 @@
 
 `/`: Landing page
 
-`/home`: Main home page for the current cycle
+`/signin`: Sign in page
 
-`/home/:id`: Main home page for any cycle with id of `id`
+`/signup`: Sign up page
+
+`/dashboard`: Main home page for the current cycle
+
+`/dashboard/:id`: Main home page for any cycle with id of `id`
 
 `/metrics`: Metrics dashboard for the current cycle
 
@@ -16,9 +20,9 @@
 
 `/settings`: Settings page for the current user
 
-`/job/:jobID`: Single job page for the job with id of `jobID` within the current cycle
+`/application/:applicationID`: Single job page for the job with id of `jobID` within the current cycle
 
-`/job/:jobID/cycleID`: Single job page for the job with id of `jobID` within the cycle with id of `cycleID`
+`/application/:applicationID/:cycleID`: Single job page for the job with id of `jobID` within the cycle with id of `cycleID`
 
 `/offers`: Offer dashboard for the current cycle
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,70 +1,25 @@
-# Getting Started with Create React App
+# NextRound Client
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## Routes
 
-## Available Scripts
+`/`: Landing page
 
-In the project directory, you can run:
+`/home`: Main home page for the current cycle
 
-### `npm start`
+`/home/:id`: Main home page for any cycle with id of `id`
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+`/metrics`: Metrics dashboard for the current cycle
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+`/metrics/:id`: Metrics dashboard for any cycle with id of `id`
 
-### `npm test`
+`/social`: Social media page
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+`/settings`: Settings page for the current user
 
-### `npm run build`
+`/job/:jobID`: Single job page for the job with id of `jobID` within the current cycle
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+`/job/:jobID/cycleID`: Single job page for the job with id of `jobID` within the cycle with id of `cycleID`
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+`/offers`: Offer dashboard for the current cycle
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+`/offers/:id`: Offer dashboard for the cycle with id of `id`


### PR DESCRIPTION
For the new user page that precedes seeing their first board, I'm assuming we still make the route /home